### PR TITLE
FIX laptop/tablet to avoid confusion in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It does not use or support standard libinput / udev libraries at this time.
 
 When the laptop is converted to tablet mode the keyboard, trackpoint and trackpad / buttons are all explicitly disabled with `xinput`.
 
-When the laptop is converted back to tablet mode, the above devices are explicitly enabled with `xinput`
+When the laptop is converted back to laptop mode, the above devices are explicitly enabled with `xinput`
 
 Reqs:
 


### PR DESCRIPTION
FIX laptop/tablet context to avoid confusion when talking about enabling with `xinput`